### PR TITLE
Exit cleanly when done with the simulation

### DIFF
--- a/src/main/java/net/acesinc/data/json/generator/JsonDataGenerator.java
+++ b/src/main/java/net/acesinc/data/json/generator/JsonDataGenerator.java
@@ -164,7 +164,6 @@ public class JsonDataGenerator {
                 Thread.sleep(1000);
             } catch (InterruptedException ex) {
                 //wakie wakie!
-                log.info("Interrupted while sleeping");
             }
         }
 

--- a/src/main/java/net/acesinc/data/json/generator/SimulationRunner.java
+++ b/src/main/java/net/acesinc/data/json/generator/SimulationRunner.java
@@ -38,7 +38,6 @@ public class SimulationRunner {
     }
 
     private void setupSimulation() {
-        running = false;
         for (WorkflowConfig workflowConfig : config.getWorkflows()) {
             try {
                 Workflow w = JSONConfigReader.readConfig(this.getClass().getClassLoader().getResourceAsStream(workflowConfig.getWorkflowFilename()), Workflow.class);


### PR DESCRIPTION
I'm not sure how this ever worked, honestly. Instead of setting a `running` boolean manually, check the status of the threads and if any of them are alive, we're running. It ain't perfect, but it's as far as I'm gonna go right now.